### PR TITLE
Remove platform files and fix subsequent damage

### DIFF
--- a/libavcodec/premake5.lua
+++ b/libavcodec/premake5.lua
@@ -1,13 +1,11 @@
 local libav_root = "../"
 project("libavcodec")
   uuid("9DB2830C-D326-48ED-B4CC-08EA6A1B7272")
-  --local_platform_files()
   files({
     "**/fdct.*",
     "**/fdctdsp_init*.c",
     "**/fft.h",
     "**/fft_init*.c",
-    --"allcodecs.c",
     "avfft.h",
     "avpacket.c",
     "bitstream.c",

--- a/libavutil/cpu.c
+++ b/libavutil/cpu.c
@@ -51,14 +51,15 @@ int av_get_cpu_flags(void)
     if (checked)
         return flags;
 
-    if (ARCH_AARCH64)
+#if ARCH_AARCH64
         flags = ff_get_cpu_flags_aarch64();
-    if (ARCH_ARM)
+#elif ARCH_ARM
         flags = ff_get_cpu_flags_arm();
-    if (ARCH_PPC)
+#elif ARCH_PPC
         flags = ff_get_cpu_flags_ppc();
-    if (ARCH_X86)
+#elif ARCH_X86
         flags = ff_get_cpu_flags_x86();
+#endif
 
     flags  &= cpuflags_mask;
     checked = 1;

--- a/libavutil/premake5.lua
+++ b/libavutil/premake5.lua
@@ -7,11 +7,12 @@ project("libavutil")
   kind("StaticLib")
   language("C")
   includedirs({
-  libav_root,
+    libav_root,
   })
-  local_platform_files()
   files({
     "**/cpu.*",
+    "*.c",
+    "*.h",
     "x86/*.c",
     "x86/*.h",
   })

--- a/libavutil/premake5.lua
+++ b/libavutil/premake5.lua
@@ -10,7 +10,6 @@ project("libavutil")
     libav_root,
   })
   files({
-    "**/cpu.*",
     "*.c",
     "*.h",
     "x86/*.c",


### PR DESCRIPTION
Instead of fixing the usage of "platform_files" script (like in benvanik/xenia#471), replace it by a simple wildcard rule.

This caused a build problem on Linux, which was fixed by removing non-x86 code.

This caused a build problem on Windows, where it complained that some functions were not found at link time, which was fixed by explicitely removing the code by using preprocessor "#ifs".

Also, I cleaned up the premake files a little.
