### PR TITLE
Fix building on latest clang

### DIFF
--- a/libavcodec/utils.c
+++ b/libavcodec/utils.c
@@ -2125,7 +2125,7 @@ const char *avcodec_configuration(void)
 const char *avcodec_license(void)
 {
 #define LICENSE_PREFIX "libavcodec license: "
-    return LICENSE_PREFIX LIBAV_LICENSE + sizeof(LICENSE_PREFIX) - 1;
+    return &LICENSE_PREFIX LIBAV_LICENSE[sizeof(LICENSE_PREFIX) - 1];
 }
 
 void avcodec_flush_buffers(AVCodecContext *avctx)

--- a/libavutil/utils.c
+++ b/libavutil/utils.c
@@ -42,7 +42,7 @@ const char *avutil_configuration(void)
 const char *avutil_license(void)
 {
 #define LICENSE_PREFIX "libavutil license: "
-    return LICENSE_PREFIX LIBAV_LICENSE + sizeof(LICENSE_PREFIX) - 1;
+    return &LICENSE_PREFIX LIBAV_LICENSE[sizeof(LICENSE_PREFIX) - 1];
 }
 
 char av_get_picture_type_char(enum AVPictureType pict_type)


### PR DESCRIPTION
In order to build xenia with clang-8, these lines must be changed.