### PR TITLE
Fix Linux build on recent systems with deprecated sys/sysctl.h

### DIFF
--- a/config_lin.h
+++ b/config_lin.h
@@ -257,7 +257,7 @@
 #define HAVE_SLEEP 0
 #define HAVE_STRERROR_R 1
 #define HAVE_SYSCONF 1
-#define HAVE_SYSCTL 1
+#define HAVE_SYSCTL 0
 #define HAVE_USLEEP 1
 #define HAVE_VIRTUALALLOC 0
 #define HAVE_PTHREADS 1


### PR DESCRIPTION
`libavutil` will automatically use the `sysconf` function instead.
No regression for older platforms is to be expected.
```
In file included from ../third_party/libav/libavutil/cpu.c:39:
/usr/include/x86_64-linux-gnu/sys/sysctl.h:21:2: error: "The <sys/sysctl.h> header is deprecated and will be removed." [-Werror,-W#warnings]
#warning "The <sys/sysctl.h> header is deprecated and will be removed."
```